### PR TITLE
people-emailedit.py

### DIFF
--- a/openstates/ca/people.py
+++ b/openstates/ca/people.py
@@ -247,8 +247,14 @@ class CAPersonScraper(Scraper):
         return person
 
     def _construct_email(self, chamber, name):
-        last_name = re.split(r'\s+', name)[-1].lower()
-
+       # last_name = re.split(r'\s+', name)[-1].lower()
+        suffix=["Ph.D.","Ret.","Sr.","Jr.","Ed.D.","II","III","IV","V","B.V.M.","CFRE","CLU","CPA","C.S.C.","C.S.J.","D.C.","D.D.","D.D.S.","D.M.D.","D.O.","D.V.M.","Inc.","J.D.","LL.D.","Ltd.","M.D.","O.D.","O.S.B.","P.C.","P.E.","R.G.S","R.N.","R.N.C.","S.H.C.J.","S.J.","S.N.J.M.","S.S.M.O.","USA","USAF","USAFR","USAR","USCG","USMC","USMCR","USN","USNR"]
+        if any(check in name for check in suffix):
+	        last_name = re.split(r'\s+', name)[-2].lower()
+        else:
+	        last_name = re.split(r'\s+', name)[-1].lower()
+        
+        
         # translate accents to non-accented versions for use in an
         # email and drop apostrophes
         last_name = ''.join(c for c in


### PR DESCRIPTION
To avoid the issue pointed out by dnoble

"State: CA

In openstates/ca/people.py, _construct_email() is trying to build email addresses with the legislator's last name. In a few cases, the suffix (Sr., Jr., Ph.D.) is used instead of the last name. This happens for assemblymembers Choi, Salas, and Jones-Sawyer:

assemblymember.phd.@assembly.ca.gov <- incorrect data has this
assemblymember.choi@assembly.ca.gov <- should be this

assemblymember.jr.@assembly.ca.gov <- incorrect data has this
assemblymember.salas@assembly.ca.gov <- should be this

assemblymember.sr.@assembly.ca.gov <- incorrect data has this
assemblymember.jones-sawyer@assembly.ca.gov <- should be this"

I have changed the last_name variable in line 250 and added the new suffix check condition before assigning a value to Last name. The idea is if there a suffix then select the second last word instead of the last word